### PR TITLE
Optimize Thread Pools

### DIFF
--- a/Bolts/src/bolts/Executors.java
+++ b/Bolts/src/bolts/Executors.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+package bolts;
+
+import android.annotation.SuppressLint;
+import android.os.Build;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This was created because the helper methods in {@link java.util.concurrent.Executors} do not work
+ * as people would normally expect.
+ *
+ * Normally, you would think that a cached thread pool would create new threads when necessary,
+ * queue them when the pool is full, and kill threads when they've been inactive for a certain
+ * period of time. This is not how {@link java.util.concurrent.Executors#newCachedThreadPool()}
+ * works.
+ *
+ * Instead, {@link java.util.concurrent.Executors#newCachedThreadPool()} executes all tasks on
+ * a new or cached thread immediately because corePoolSize is 0, SynchronousQueue is a queue with
+ * size 0 and maxPoolSize is Integer.MAX_VALUE. This is dangerous because it can create an unchecked
+ * amount of threads.
+ */
+
+/** package */ final class Executors {
+
+  private Executors() {
+    // do nothing
+  }
+
+  /**
+   * Nexus 5: Quad-Core
+   * Moto X: Dual-Core
+   *
+   * AsyncTask:
+   *   CORE_POOL_SIZE = CPU_COUNT + 1
+   *   MAX_POOL_SIZE = CPU_COUNT * 2 + 1
+   *
+   * https://github.com/android/platform_frameworks_base/commit/719c44e03b97e850a46136ba336d729f5fbd1f47
+   */
+  private static final int CPU_COUNT = Runtime.getRuntime().availableProcessors();
+  /* package */ static final int CORE_POOL_SIZE = CPU_COUNT + 1;
+  /* package */ static final int MAX_POOL_SIZE = CPU_COUNT * 2 + 1;
+  /* package */ static final long KEEP_ALIVE_TIME = 1L;
+  /* package */ static final int MAX_QUEUE_SIZE = 128;
+
+  /**
+   * Creates a proper Cached Thread Pool. Tasks will reuse cached threads if available
+   * or create new threads until the core pool is full. tasks will then be queued. If an
+   * task cannot be queued, a new thread will be created unless this would exceed max pool
+   * size, then the task will be rejected. Threads will time out after 1 second.
+   *
+   * Core thread timeout is only available on android-9+.
+   *
+   * @return the newly created thread pool
+   */
+  public static ExecutorService newCachedThreadPool() {
+    ThreadPoolExecutor executor =  new ThreadPoolExecutor(
+        CORE_POOL_SIZE,
+        MAX_POOL_SIZE,
+        KEEP_ALIVE_TIME, TimeUnit.SECONDS,
+        new LinkedBlockingQueue<Runnable>(MAX_QUEUE_SIZE));
+
+    allowCoreThreadTimeout(executor, true);
+
+    return executor;
+  }
+
+  /**
+   * Creates a proper Cached Thread Pool. Tasks will reuse cached threads if available
+   * or create new threads until the core pool is full. tasks will then be queued. If an
+   * task cannot be queued, a new thread will be created unless this would exceed max pool
+   * size, then the task will be rejected. Threads will time out after 1 second.
+   *
+   * Core thread timeout is only available on android-9+.
+   *
+   * @param threadFactory the factory to use when creating new threads
+   * @return the newly created thread pool
+   */
+  public static ExecutorService newCachedThreadPool(ThreadFactory threadFactory) {
+    ThreadPoolExecutor executor =  new ThreadPoolExecutor(
+            CORE_POOL_SIZE,
+            MAX_POOL_SIZE,
+            KEEP_ALIVE_TIME, TimeUnit.SECONDS,
+            new LinkedBlockingQueue<Runnable>(MAX_QUEUE_SIZE),
+            threadFactory);
+
+    allowCoreThreadTimeout(executor, true);
+
+    return executor;
+  }
+
+  /**
+   * Compatibility helper function for
+   * {@link java.util.concurrent.ThreadPoolExecutor#allowCoreThreadTimeOut(boolean)}
+   *
+   * Only available on android-9+.
+   *
+   * @param executor the {@link java.util.concurrent.ThreadPoolExecutor}
+   * @param value true if should time out, else false
+   */
+  @SuppressLint("NewApi")
+  public static void allowCoreThreadTimeout(ThreadPoolExecutor executor, boolean value) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
+      executor.allowCoreThreadTimeOut(value);
+    }
+  }
+}

--- a/BoltsTest/src/bolts/ExecutorsTest.java
+++ b/BoltsTest/src/bolts/ExecutorsTest.java
@@ -1,0 +1,196 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+package bolts;
+
+import android.os.Build;
+import android.test.InstrumentationTestCase;
+
+import java.util.LinkedList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
+
+public class ExecutorsTest extends InstrumentationTestCase {
+
+  private static final int CORE_POOL_SIZE = Executors.CORE_POOL_SIZE;
+  private static final int MAX_POOL_SIZE = Executors.MAX_POOL_SIZE;
+  private static final int THREAD_TIMEOUT = (int)(Executors.KEEP_ALIVE_TIME * 1000 * 1.1);
+  private static final int MAX_QUEUE_SIZE = Executors.MAX_QUEUE_SIZE;
+
+  LinkedList<CountDownLatch> corePoolAwaitLatchStack;
+  LinkedList<CountDownLatch> corePoolEndLatchStack;
+
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+
+    corePoolAwaitLatchStack = new LinkedList<CountDownLatch>();
+    corePoolEndLatchStack = new LinkedList<CountDownLatch>();
+  }
+
+  /**
+   * Test whether or not the core pool will time out.
+   *
+   * Core pool only times out to 0 on android-9+ only
+   *
+   * @throws InterruptedException
+   */
+  public void testNewCachedThreadPoolTimeout() throws InterruptedException {
+    ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
+
+    // Make sure we start at 0
+    assertEquals(0, executor.getPoolSize());
+
+    // Fill core pool
+    pushTasks(executor, CORE_POOL_SIZE, true);
+    assertEquals(CORE_POOL_SIZE, executor.getPoolSize());
+    assertEquals(0, executor.getQueue().size());
+
+    // Empty core pool
+    popTasks(true);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
+      assertEquals(0, executor.getPoolSize());
+    } else {
+      assertEquals(CORE_POOL_SIZE, executor.getPoolSize());
+    }
+  }
+
+  /**
+   * Test that the queue gets filled and throws if filled over the max.
+   *
+   * Note: Core thread pool timeout is only available on android-9+
+   *
+   * @throws InterruptedException
+   */
+  public void testNewCachedThreadPoolQueue() throws InterruptedException {
+    ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
+    assertEquals(0, executor.getPoolSize());
+    pushTasks(executor, CORE_POOL_SIZE, true);
+
+    try {
+      // Fill queue to max
+      pushTasks(executor, MAX_QUEUE_SIZE, false);
+      assertEquals(CORE_POOL_SIZE, executor.getPoolSize());
+      assertEquals(MAX_QUEUE_SIZE, executor.getQueue().size());
+
+      // Overflow queue
+      pushTasks(executor, MAX_POOL_SIZE, false);
+      assertEquals(MAX_POOL_SIZE, executor.getPoolSize());
+      assertEquals(MAX_QUEUE_SIZE, executor.getQueue().size());
+
+      executor.execute(newWaitRunnable(null, null, null));
+      fail("Failed to reject operation due to full queue");
+    } catch (RejectedExecutionException e) {
+      // Do we still have our queue?
+      assertEquals(MAX_POOL_SIZE, executor.getPoolSize());
+      assertEquals(MAX_QUEUE_SIZE, executor.getQueue().size());
+    } finally {
+      // empty overflow
+      popTasks(false);
+      // empty queue
+      popTasks(false);
+    }
+
+    popTasks(true);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
+      assertEquals(0, executor.getPoolSize());
+    } else {
+      assertEquals(CORE_POOL_SIZE, executor.getPoolSize());
+    }
+  }
+
+  /**
+   * Push or start X operations on to the executor that will not complete until they are popped off.
+   *
+   * @see ExecutorsTest#popTasks(boolean)
+   *
+   * @param executor
+   *          The executor to execute operations on.
+   * @param count
+   *          How many operations to execute.
+   * @param waitForStart
+   *          Control whether or not to wait until all the operations start to complete before
+   *          returning from this method.
+   * @throws InterruptedException
+   */
+  private void pushTasks(ExecutorService executor, int count, boolean waitForStart)
+      throws InterruptedException {
+    CountDownLatch startLatch = waitForStart ? new CountDownLatch(count) : null;
+    CountDownLatch awaitLatch = new CountDownLatch(1);
+    CountDownLatch endLatch = new CountDownLatch(count);
+
+    corePoolAwaitLatchStack.add(0, awaitLatch);
+    corePoolEndLatchStack.add(0, endLatch);
+
+    for (int i = 0; i < count; i++) {
+      executor.execute(newWaitRunnable(startLatch, awaitLatch, endLatch));
+    }
+
+    if (startLatch != null) {
+      startLatch.await();
+    }
+  }
+
+  /**
+   * Pop or end the last group of pushed operations.
+   *
+   * @param waitForEnd
+   *          Control whether or not to wait until all the operations complete before returning from
+   *          this method.
+   * @throws InterruptedException
+   */
+  private void popTasks(boolean waitForEnd) throws InterruptedException {
+    CountDownLatch awaitLatch = corePoolAwaitLatchStack.remove(0);
+    CountDownLatch endLatch = corePoolEndLatchStack.remove(0);
+
+    awaitLatch.countDown();
+    if (waitForEnd) {
+      endLatch.await();
+    }
+    // Wait for threads to die
+    Thread.sleep(THREAD_TIMEOUT);
+  }
+
+  /**
+   * Creates a new waitable runnable.
+   *
+   * @param startLatch
+   *          Latch that alerts the operation has started.
+   * @param awaitLatch
+   *          Latch that keeps the operation running.
+   * @param endLatch
+   *          Latch that alerts the operation has completed.
+   * @return
+   */
+  private Runnable newWaitRunnable(final CountDownLatch startLatch,
+      final CountDownLatch awaitLatch, final CountDownLatch endLatch) {
+    return new Runnable() {
+      @Override
+      public void run() {
+        if (startLatch != null) {
+          startLatch.countDown();
+        }
+
+        if (awaitLatch != null) {
+          try {
+            awaitLatch.await();
+          } catch (InterruptedException e) {
+            // do nothing
+          }
+        }
+
+        if (endLatch != null) {
+          endLatch.countDown();
+        }
+      }
+    };
+  }
+}

--- a/BoltsTest/src/bolts/TaskTest.java
+++ b/BoltsTest/src/bolts/TaskTest.java
@@ -19,6 +19,7 @@ import bolts.AggregateException;
 import bolts.Continuation;
 import bolts.Task;
 
+import android.os.Looper;
 import android.test.InstrumentationTestCase;
 
 public class TaskTest extends InstrumentationTestCase {
@@ -191,6 +192,35 @@ public class TaskTest extends InstrumentationTestCase {
             return null;
           }
         });
+      }
+    });
+  }
+
+  public void testContinueOnUiThread() {
+    assertNotSame(Looper.myLooper(), Looper.getMainLooper());
+
+    runTaskTest(new Callable<Task<?>>() {
+      @Override
+      public Task<Void> call() throws Exception {
+        return Task.call(new Callable<Void>() {
+          @Override
+          public Void call() throws Exception {
+            assertSame(Looper.myLooper(), Looper.getMainLooper());
+            return null;
+          }
+        }, Task.UI_THREAD_EXECUTOR).continueWith(new Continuation<Void, Void>() {
+          @Override
+          public Void then(Task<Void> task) throws Exception {
+            assertNotSame(Looper.myLooper(), Looper.getMainLooper());
+            return null;
+          }
+        }, Task.BACKGROUND_EXECUTOR).continueWith(new Continuation<Void, Void>() {
+          @Override
+          public Void then(Task<Void> task) throws Exception {
+            assertSame(Looper.myLooper(), Looper.getMainLooper());
+            return null;
+          }
+        }, Task.UI_THREAD_EXECUTOR);
       }
     });
   }


### PR DESCRIPTION
- Optimize number of threads in pool based on available processors
- Kill core threads when not in use (android-8+)
- com.parse.Executors#newCachedThreadPool works the way you'd want it to
  - Reuses threads in pool if available
  - Creates more threads until core pool size
  - Queues threads until queue size
  - Creates more threads until max pool size
  - Rejects
- Add Task#UI_THREAD_EXECUTOR to continue work on the UI thread.
