### PR TITLE
Update to allow usage on Android and JVM

### DIFF
--- a/Bolts/src/bolts/BoltsExecutors.java
+++ b/Bolts/src/bolts/BoltsExecutors.java
@@ -1,0 +1,108 @@
+package bolts;
+
+import java.util.Locale;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+
+import bolts.android.AndroidExecutors;
+
+/**
+ * Collection of {@link Executor}s to use in conjunction with {@link Task}.
+ */
+public final class BoltsExecutors {
+
+  private static final BoltsExecutors INSTANCE = new BoltsExecutors();
+
+  private static boolean isAndroidRuntime() {
+    String javaRuntimeName = System.getProperty("java.runtime.name");
+    if (javaRuntimeName == null) {
+      return false;
+    }
+    return javaRuntimeName.toLowerCase(Locale.US).contains("android");
+  }
+
+  private final ExecutorService background;
+  private final Executor immediate;
+
+  private BoltsExecutors() {
+    background = !isAndroidRuntime()
+        ? java.util.concurrent.Executors.newCachedThreadPool()
+        : AndroidExecutors.newCachedThreadPool();
+    immediate = new ImmediateExecutor();
+  }
+
+  /**
+   * An {@link java.util.concurrent.Executor} that executes tasks in parallel.
+   */
+  public static ExecutorService background() {
+    return INSTANCE.background;
+  }
+
+  /**
+   * An {@link java.util.concurrent.Executor} that executes tasks in the current thread unless
+   * the stack runs too deep, at which point it will delegate to {@link BoltsExecutors#background}
+   * in order to trim the stack.
+   */
+  /* package */ static Executor immediate() {
+    return INSTANCE.immediate;
+  }
+
+  /**
+   * An {@link java.util.concurrent.Executor} that runs a runnable inline (rather than scheduling it
+   * on a thread pool) as long as the recursion depth is less than MAX_DEPTH. If the executor has
+   * recursed too deeply, it will instead delegate to the {@link Task#BACKGROUND_EXECUTOR} in order
+   * to trim the stack.
+   */
+  private static class ImmediateExecutor implements Executor {
+    private static final int MAX_DEPTH = 15;
+    private ThreadLocal<Integer> executionDepth = new ThreadLocal<Integer>();
+
+    /**
+     * Increments the depth.
+     *
+     * @return the new depth value.
+     */
+    private int incrementDepth() {
+      Integer oldDepth = executionDepth.get();
+      if (oldDepth == null) {
+        oldDepth = 0;
+      }
+      int newDepth = oldDepth + 1;
+      executionDepth.set(newDepth);
+      return newDepth;
+    }
+
+    /**
+     * Decrements the depth.
+     *
+     * @return the new depth value.
+     */
+    private int decrementDepth() {
+      Integer oldDepth = executionDepth.get();
+      if (oldDepth == null) {
+        oldDepth = 0;
+      }
+      int newDepth = oldDepth - 1;
+      if (newDepth == 0) {
+        executionDepth.remove();
+      } else {
+        executionDepth.set(newDepth);
+      }
+      return newDepth;
+    }
+
+    @Override
+    public void execute(Runnable command) {
+      int depth = incrementDepth();
+      try {
+        if (depth <= MAX_DEPTH) {
+          command.run();
+        } else {
+          BoltsExecutors.background().execute(command);
+        }
+      } finally {
+        decrementDepth();
+      }
+    }
+  }
+}

--- a/Bolts/src/bolts/android/AndroidExecutors.java
+++ b/Bolts/src/bolts/android/AndroidExecutors.java
@@ -7,11 +7,14 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
-package bolts;
+package bolts.android;
 
 import android.annotation.SuppressLint;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
@@ -32,11 +35,14 @@ import java.util.concurrent.TimeUnit;
  * size 0 and maxPoolSize is Integer.MAX_VALUE. This is dangerous because it can create an unchecked
  * amount of threads.
  */
+public final class AndroidExecutors {
 
-/** package */ final class Executors {
+  private static final AndroidExecutors INSTANCE = new AndroidExecutors();
 
-  private Executors() {
-    // do nothing
+  private final Executor uiThread;
+
+  private AndroidExecutors() {
+    uiThread = new UIThreadExecutor();
   }
 
   /**
@@ -114,6 +120,23 @@ import java.util.concurrent.TimeUnit;
   public static void allowCoreThreadTimeout(ThreadPoolExecutor executor, boolean value) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
       executor.allowCoreThreadTimeOut(value);
+    }
+  }
+
+  /**
+   * An {@link java.util.concurrent.Executor} that executes tasks on the UI thread.
+   */
+  public static Executor uiThread() {
+    return INSTANCE.uiThread;
+  }
+
+  /**
+   * An {@link java.util.concurrent.Executor} that runs tasks on the UI thread.
+   */
+  private static class UIThreadExecutor implements Executor {
+    @Override
+    public void execute(Runnable command) {
+      new Handler(Looper.getMainLooper()).post(command);
     }
   }
 }

--- a/BoltsTest/src/bolts/android/AndroidExecutorsTest.java
+++ b/BoltsTest/src/bolts/android/AndroidExecutorsTest.java
@@ -7,7 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
-package bolts;
+package bolts.android;
 
 import android.os.Build;
 import android.test.InstrumentationTestCase;
@@ -18,12 +18,12 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ThreadPoolExecutor;
 
-public class ExecutorsTest extends InstrumentationTestCase {
+public class AndroidExecutorsTest extends InstrumentationTestCase {
 
-  private static final int CORE_POOL_SIZE = Executors.CORE_POOL_SIZE;
-  private static final int MAX_POOL_SIZE = Executors.MAX_POOL_SIZE;
-  private static final int THREAD_TIMEOUT = (int)(Executors.KEEP_ALIVE_TIME * 1000 * 1.1);
-  private static final int MAX_QUEUE_SIZE = Executors.MAX_QUEUE_SIZE;
+  private static final int CORE_POOL_SIZE = AndroidExecutors.CORE_POOL_SIZE;
+  private static final int MAX_POOL_SIZE = AndroidExecutors.MAX_POOL_SIZE;
+  private static final int THREAD_TIMEOUT = (int)(AndroidExecutors.KEEP_ALIVE_TIME * 1000 * 1.1);
+  private static final int MAX_QUEUE_SIZE = AndroidExecutors.MAX_QUEUE_SIZE;
 
   LinkedList<CountDownLatch> corePoolAwaitLatchStack;
   LinkedList<CountDownLatch> corePoolEndLatchStack;
@@ -44,7 +44,7 @@ public class ExecutorsTest extends InstrumentationTestCase {
    * @throws InterruptedException
    */
   public void testNewCachedThreadPoolTimeout() throws InterruptedException {
-    ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
+    ThreadPoolExecutor executor = (ThreadPoolExecutor) AndroidExecutors.newCachedThreadPool();
 
     // Make sure we start at 0
     assertEquals(0, executor.getPoolSize());
@@ -71,7 +71,7 @@ public class ExecutorsTest extends InstrumentationTestCase {
    * @throws InterruptedException
    */
   public void testNewCachedThreadPoolQueue() throws InterruptedException {
-    ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
+    ThreadPoolExecutor executor = (ThreadPoolExecutor) AndroidExecutors.newCachedThreadPool();
     assertEquals(0, executor.getPoolSize());
     pushTasks(executor, CORE_POOL_SIZE, true);
 
@@ -110,7 +110,7 @@ public class ExecutorsTest extends InstrumentationTestCase {
   /**
    * Push or start X operations on to the executor that will not complete until they are popped off.
    *
-   * @see ExecutorsTest#popTasks(boolean)
+   * @see AndroidExecutorsTest#popTasks(boolean)
    *
    * @param executor
    *          The executor to execute operations on.


### PR DESCRIPTION
- Use AndroidExecutors on Android
- Fallback to java.util.concurrent.Executors on JVM
- Publicize bolts.android.AndroidExecutors
- Create BoltsExecutors 
- Clear warnings
