### PR TITLE
AppLink Events

### DIFF
--- a/Bolts/src/bolts/AppLinks.java
+++ b/Bolts/src/bolts/AppLinks.java
@@ -9,6 +9,7 @@
  */
 package bolts;
 
+import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -18,12 +19,14 @@ import android.os.Bundle;
  * data.
  */
 public final class AppLinks {
+
   static final String KEY_NAME_APPLINK_DATA = "al_applink_data";
   static final String KEY_NAME_EXTRAS = "extras";
   static final String KEY_NAME_TARGET = "target_url";
 
   /**
    * Gets the App Link data for an intent, if there is any.
+   * This is the authorized function to check if an intent is AppLink. If null is returned it is not.
    *
    * @param intent the incoming intent.
    * @return a bundle containing the App Link data for the intent, or {@code null} if none
@@ -65,5 +68,25 @@ public final class AppLinks {
       }
     }
     return intent.getData();
+  }
+
+  /**
+   * Gets the target URL for an intent. If the intent is from an App Link, this will be the App Link target.
+   * Otherwise, it return null; For app link intent, this function will broadcast APP_LINK_NAVIGATE_IN_EVENT_NAME event.
+   *
+   * @param context the context this function is called within.
+   * @param intent the incoming intent.
+   * @return the target URL for the intent if applink intent; null otherwise.
+   */
+  public static Uri getTargetUrlFromInboundIntent(Context context, Intent intent) {
+    Bundle appLinkData = getAppLinkData(intent);
+    if (appLinkData != null) {
+      String targetString = appLinkData.getString(KEY_NAME_TARGET);
+      if (targetString != null) {
+        MeasurementEvent.sendBroadcastEvent(context, MeasurementEvent.APP_LINK_NAVIGATE_IN_EVENT_NAME, intent, null);
+        return Uri.parse(targetString);
+      }
+    }
+    return null;
   }
 }

--- a/Bolts/src/bolts/MeasurementEvent.java
+++ b/Bolts/src/bolts/MeasurementEvent.java
@@ -1,0 +1,217 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+package bolts;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Bundle;
+import android.util.Log;
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ *  Bolts raises events to the application by sending local broadcasts.
+ *  Application integrated to Bolts can listen to events by registering BroadcastReceiver with
+ *  intent filter {@link #MEASUREMENT_EVENT_NOTIFICATION_NAME}. When receive the event,
+ *  a String field {@link #MEASUREMENT_EVENT_NAME_KEY} and A Bundle field @{link #MEASUREMENT_EVENT_ARGS_KEY}
+ *  in Intent extra in indicate the event name and arguments with this event.
+ */
+public class MeasurementEvent {
+  /**
+   *  The action of the broadcast intent that represents Bolts measurement event.
+   */
+  public static final String MEASUREMENT_EVENT_NOTIFICATION_NAME = "com.parse.bolts.measurement_event";
+
+  /**
+   * The field name in the broadcast intent extra bundle that represents Bolts measurement event name.
+   */
+  public static final String MEASUREMENT_EVENT_NAME_KEY = "event_name";
+
+  /**
+   * The field name in the broadcast intent extra bundle that represents Bolts measurement event arguments.
+   */
+  public static final String MEASUREMENT_EVENT_ARGS_KEY = "event_args";
+
+  // Events
+  /**
+   * The name for event of navigating out to other apps. Event raised in navigation methods, e.g.
+   * {@link bolts.AppLinkNavigation#navigateInBackground(android.content.Context, String)}
+   **/
+  public static final String APP_LINK_NAVIGATE_OUT_EVENT_NAME = "al_nav_out";
+
+  /**
+   *  The name for event of handling incoming applink intent. Event raised in
+   *  {@link bolts.AppLinks#getTargetUrlFromInboundIntent(android.content.Context, android.content.Intent)}
+   **/
+  public static final String APP_LINK_NAVIGATE_IN_EVENT_NAME = "al_nav_in";
+
+  /**
+   *  Broadcast Bolts measurement event.
+   *  Bolts raises events to the application with this method by sending
+   *  {@link #MEASUREMENT_EVENT_NOTIFICATION_NAME} broadcast.
+   *
+   *  @param context the context of activity or application who is going to send the event. required.
+   *  @param name the event name that is going to be sent. required.
+   *  @param intent the intent that carries the logging data in its extra bundle and data url. optional.
+   *  @param extraLoggingData other logging data to be sent in events argument. optional.
+   *
+   */
+  static void sendBroadcastEvent(
+      Context context,
+      String name,
+      Intent intent,
+      Map<String, String> extraLoggingData) {
+    Bundle logData = new Bundle();
+    if (intent != null) {
+      Bundle applinkData = AppLinks.getAppLinkData(intent);
+      if (applinkData != null) {
+        logData = getApplinkLogData(context, name, applinkData, intent);
+      } else {
+        Uri intentUri = intent.getData();
+        if (intentUri != null) {
+          logData.putString("intentData", intentUri.toString());
+        }
+        Bundle intentExtras = intent.getExtras();
+        if (intentExtras != null) {
+          for (String key : intentExtras.keySet()) {
+            Object o = intentExtras.get(key);
+            String logValue = objectToJSONString(o);
+            logData.putString(key, logValue);
+          }
+        }
+      }
+    }
+
+    if (extraLoggingData != null) {
+      for (String key : extraLoggingData.keySet()) {
+        logData.putString(key, extraLoggingData.get(key));
+      }
+    }
+    MeasurementEvent event = new MeasurementEvent(context, name, logData);
+    event.sendBroadcast();
+  }
+
+  private Context appContext;
+  private String name;
+  private Bundle args;
+
+  private MeasurementEvent(Context context, String eventName, Bundle eventArgs) {
+    appContext = context.getApplicationContext();
+    name = eventName;
+    args = eventArgs;
+  }
+
+  private void sendBroadcast() {
+    if (name == null) {
+      Log.d(getClass().getName(), "Event name is required");
+    }
+    try {
+      Class<?> clazz = Class.forName("android.support.v4.content.LocalBroadcastManager");
+      Method methodGetInstance = clazz.getMethod("getInstance", Context.class);
+      Method methodSendBroadcast = clazz.getMethod("sendBroadcast", Intent.class);
+      Object localBroadcastManager = methodGetInstance.invoke(null, appContext);
+      Intent event = new Intent(MEASUREMENT_EVENT_NOTIFICATION_NAME);
+      event.putExtra(MEASUREMENT_EVENT_NAME_KEY, name);
+      event.putExtra(MEASUREMENT_EVENT_ARGS_KEY, args);
+      methodSendBroadcast.invoke(localBroadcastManager, event);
+    } catch (Exception e) {
+      Log.d(getClass().getName(),
+          "LocalBroadcastManager in android support library is required to raise bolts event.");
+    }
+  }
+
+  private static Bundle getApplinkLogData(Context context, String eventName, Bundle appLinkData, Intent applinkIntent) {
+    Bundle logData = new Bundle();
+    ComponentName resolvedActivity = applinkIntent.resolveActivity(context.getPackageManager());
+
+    if (resolvedActivity != null) {
+      logData.putString("class", resolvedActivity.getShortClassName());
+    }
+
+    if (APP_LINK_NAVIGATE_OUT_EVENT_NAME.equals(eventName)) {
+      if (resolvedActivity != null) {
+        logData.putString("package", resolvedActivity.getPackageName());
+      }
+      if (applinkIntent.getData() != null) {
+        logData.putString("outputURL", applinkIntent.getData().toString());
+      }
+      if (applinkIntent.getScheme() != null) {
+        logData.putString("outputURLScheme", applinkIntent.getScheme());
+      }
+    } else if (APP_LINK_NAVIGATE_IN_EVENT_NAME.equals(eventName)) {
+      if (applinkIntent.getData() != null) {
+        logData.putString("inputURL", applinkIntent.getData().toString());
+      }
+      if (applinkIntent.getScheme() != null) {
+        logData.putString("inputURLScheme", applinkIntent.getScheme());
+      }
+    }
+
+    for (String key : appLinkData.keySet()) {
+      Object o = appLinkData.get(key);
+      if (o instanceof Bundle) {
+        for (String subKey : ((Bundle) o).keySet()) {
+          String logValue = objectToJSONString(((Bundle) o).get(subKey));
+          if (key.equals("referer_app_link")) {
+            if (subKey.equalsIgnoreCase("url")) {
+              logData.putString("refererURL", logValue);
+              continue;
+            } else if (subKey.equalsIgnoreCase("app_name")) {
+              logData.putString("refererAppName", logValue);
+              continue;
+            } else if (subKey.equalsIgnoreCase("package")) {
+              logData.putString("sourceApplication", logValue);
+              continue;
+            }
+          }
+          logData.putString(key + "/" + subKey, logValue);
+        }
+      } else {
+        String logValue = objectToJSONString(o);
+        if (key.equals("target_url")) {
+          Uri targetURI = Uri.parse(logValue);
+          logData.putString("targetURL", targetURI.toString());
+          logData.putString("targetURLHost", targetURI.getHost());
+          continue;
+        }
+        logData.putString(key, logValue);
+      }
+    }
+    return logData;
+  }
+
+  private static String objectToJSONString(Object o) {
+    if (o == null) {
+      return null;
+    }
+    if (o instanceof JSONArray || o instanceof JSONObject) {
+      return o.toString();
+    }
+
+    try {
+      if (o instanceof Collection) {
+        return (new JSONArray((Collection) o)).toString();
+      }
+      if (o instanceof Map) {
+        return (new JSONObject((Map) o)).toString();
+      }
+      return o.toString();
+    } catch (Exception ignored) {
+    }
+    return null;
+  }
+}

--- a/BoltsTest/build.gradle
+++ b/BoltsTest/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'com.android.application'
 
 dependencies {
+    androidTestCompile "com.android.support:support-v4:13+"
     compile project(':Bolts')
 }
 

--- a/BoltsTest/src/bolts/AppLinkTest.java
+++ b/BoltsTest/src/bolts/AppLinkTest.java
@@ -9,15 +9,17 @@
  */
 package bolts;
 
+import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.content.Intent;
+import android.content.IntentFilter;
 import android.net.Uri;
 import android.os.Bundle;
+import android.support.v4.content.LocalBroadcastManager;
 import android.test.InstrumentationTestCase;
-
 import junit.framework.Assert;
-
+import org.json.JSONArray;
 import org.json.JSONObject;
 
 import java.io.File;
@@ -25,7 +27,11 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class AppLinkTest extends InstrumentationTestCase {
   private List<Intent> openedIntents;
@@ -105,6 +111,94 @@ public class AppLinkTest extends InstrumentationTestCase {
     Assert.assertNotNull(AppLinks.getAppLinkData(i));
     Assert.assertNotNull(AppLinks.getAppLinkExtras(i));
     Assert.assertEquals("bar", AppLinks.getAppLinkExtras(i).getString("foo"));
+  }
+
+  public void testGeneralMeasurementEventsBroadcast() throws Exception {
+    Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"));
+    i.putExtra("foo", "bar");
+    ArrayList<String> arr = new ArrayList<String>();
+    arr.add("foo2");
+    arr.add("bar2");
+    i.putExtra("foobar", arr);
+    Map<String, String> other = new HashMap<String, String>();
+    other.put("yetAnotherFoo", "yetAnotherBar");
+
+    final CountDownLatch lock = new CountDownLatch(1);
+    final String[] receivedStrings = new String[5];
+    LocalBroadcastManager manager = LocalBroadcastManager.getInstance(getInstrumentation().getTargetContext());
+    manager.registerReceiver(
+        new BroadcastReceiver() {
+          @Override
+          public void onReceive(Context context, Intent intent) {
+            String eventName = intent.getStringExtra("event_name");
+            Bundle eventArgs = intent.getBundleExtra("event_args");
+            receivedStrings[0] = eventName;
+            receivedStrings[1] = eventArgs.getString("foo");
+            receivedStrings[2] = eventArgs.getString("foobar");
+            receivedStrings[3] = eventArgs.getString("yetAnotherFoo");
+            receivedStrings[4] = eventArgs.getString("intentData");
+            lock.countDown();
+          }
+        },
+        new IntentFilter("com.parse.bolts.measurement_event")
+    );
+
+    MeasurementEvent.sendBroadcastEvent(getInstrumentation().getTargetContext(), "myEventName", i, other);
+    lock.await(2000, TimeUnit.MILLISECONDS);
+
+    assertEquals("myEventName", receivedStrings[0]);
+    assertEquals("bar", receivedStrings[1]);
+    assertEquals((new JSONArray(arr)).toString(), receivedStrings[2]);
+    assertEquals("yetAnotherBar", receivedStrings[3]);
+    assertEquals("http://www.example.com", receivedStrings[4]);
+  }
+
+  public void testAppLinkNavInEventBroadcast() throws Exception {
+    Intent i = new Intent(Intent.ACTION_VIEW, Uri.parse("http://www.example.com"));
+    Bundle appLinkData = new Bundle();
+    appLinkData.putString("target_url", "http://www.example2.com");
+    Bundle appLinkRefererData = new Bundle();
+    appLinkRefererData.putString("url", "referer://");
+    appLinkRefererData.putString("app_name", "Referrer App");
+    appLinkRefererData.putString("package", "com.bolts.referrer");
+    appLinkData.putBundle("referer_app_link", appLinkRefererData);
+    Bundle applinkExtras = new Bundle();
+    applinkExtras.putString("token", "a_token");
+    appLinkData.putBundle("extras", applinkExtras);
+    i.putExtra("al_applink_data", appLinkData);
+
+    final CountDownLatch lock = new CountDownLatch(1);
+    final String[] receivedStrings = new String[7];
+    LocalBroadcastManager manager = LocalBroadcastManager.getInstance(getInstrumentation().getTargetContext());
+    manager.registerReceiver(
+        new BroadcastReceiver() {
+          @Override
+          public void onReceive(Context context, Intent intent) {
+            String eventName = intent.getStringExtra("event_name");
+            Bundle eventArgs = intent.getBundleExtra("event_args");
+            receivedStrings[0] = eventName;
+            receivedStrings[1] = eventArgs.getString("targetURL");
+            receivedStrings[2] = eventArgs.getString("inputURL");
+            receivedStrings[3] = eventArgs.getString("refererURL");
+            receivedStrings[4] = eventArgs.getString("refererAppName");
+            receivedStrings[5] = eventArgs.getString("extras/token");
+            receivedStrings[6] = eventArgs.getString("sourceApplication");
+            lock.countDown();
+          }
+        },
+        new IntentFilter("com.parse.bolts.measurement_event")
+    );
+
+    Uri targetUrl = AppLinks.getTargetUrlFromInboundIntent(getInstrumentation().getTargetContext(), i);
+    lock.await(2000, TimeUnit.MILLISECONDS);
+
+    assertEquals("al_nav_in", receivedStrings[0]);
+    assertEquals("http://www.example2.com", receivedStrings[1]);
+    assertEquals("http://www.example.com", receivedStrings[2]);
+    assertEquals("referer://", receivedStrings[3]);
+    assertEquals("Referrer App", receivedStrings[4]);
+    assertEquals("a_token", receivedStrings[5]);
+    assertEquals("com.bolts.referrer", receivedStrings[6]);
   }
 
   public void testWebViewSimpleAppLinkParsing() throws Exception {


### PR DESCRIPTION
Besides the "revert of revert",  these are newly added:
1. getAppLinkData from Intent.getData as well
2. compatible with protocol to release
3. add unit test
4. provided gradle dependencies the support lib without actually adding it.
5. avoid crash for built Bolts, if using applink without requiring 'support' lib.

add support lib as provided dependencies
