### PR TITLE
Hide AndroidExecutors and BoltsExecutors

### DIFF
--- a/Bolts/src/bolts/AndroidExecutors.java
+++ b/Bolts/src/bolts/AndroidExecutors.java
@@ -7,7 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
-package bolts.android;
+package bolts;
 
 import android.annotation.SuppressLint;
 import android.os.Build;
@@ -35,7 +35,7 @@ import java.util.concurrent.TimeUnit;
  * size 0 and maxPoolSize is Integer.MAX_VALUE. This is dangerous because it can create an unchecked
  * amount of threads.
  */
-public final class AndroidExecutors {
+/* package */ final class AndroidExecutors {
 
   private static final AndroidExecutors INSTANCE = new AndroidExecutors();
 

--- a/Bolts/src/bolts/BoltsExecutors.java
+++ b/Bolts/src/bolts/BoltsExecutors.java
@@ -4,12 +4,10 @@ import java.util.Locale;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 
-import bolts.android.AndroidExecutors;
-
 /**
  * Collection of {@link Executor}s to use in conjunction with {@link Task}.
  */
-public final class BoltsExecutors {
+/* package */ final class BoltsExecutors {
 
   private static final BoltsExecutors INSTANCE = new BoltsExecutors();
 

--- a/Bolts/src/bolts/Task.java
+++ b/Bolts/src/bolts/Task.java
@@ -18,8 +18,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import bolts.android.AndroidExecutors;
-
 /**
  * Represents the result of an asynchronous operation.
  * 

--- a/BoltsTest/src/bolts/AndroidExecutorsTest.java
+++ b/BoltsTest/src/bolts/AndroidExecutorsTest.java
@@ -7,7 +7,7 @@
  *  of patent rights can be found in the PATENTS file in the same directory.
  *
  */
-package bolts.android;
+package bolts;
 
 import android.os.Build;
 import android.test.InstrumentationTestCase;


### PR DESCRIPTION
It seems odd to have two ways to access the executors, so we'll publicize these at a future date when we decide on a stable API.
