### PR TITLE
Remove 128 queue limit for AndroidExecutors.newCachedThreadPool

### DIFF
--- a/Bolts/src/bolts/AndroidExecutors.java
+++ b/Bolts/src/bolts/AndroidExecutors.java
@@ -59,7 +59,6 @@ import java.util.concurrent.TimeUnit;
   /* package */ static final int CORE_POOL_SIZE = CPU_COUNT + 1;
   /* package */ static final int MAX_POOL_SIZE = CPU_COUNT * 2 + 1;
   /* package */ static final long KEEP_ALIVE_TIME = 1L;
-  /* package */ static final int MAX_QUEUE_SIZE = 128;
 
   /**
    * Creates a proper Cached Thread Pool. Tasks will reuse cached threads if available
@@ -76,7 +75,7 @@ import java.util.concurrent.TimeUnit;
         CORE_POOL_SIZE,
         MAX_POOL_SIZE,
         KEEP_ALIVE_TIME, TimeUnit.SECONDS,
-        new LinkedBlockingQueue<Runnable>(MAX_QUEUE_SIZE));
+        new LinkedBlockingQueue<Runnable>());
 
     allowCoreThreadTimeout(executor, true);
 
@@ -99,7 +98,7 @@ import java.util.concurrent.TimeUnit;
             CORE_POOL_SIZE,
             MAX_POOL_SIZE,
             KEEP_ALIVE_TIME, TimeUnit.SECONDS,
-            new LinkedBlockingQueue<Runnable>(MAX_QUEUE_SIZE),
+            new LinkedBlockingQueue<Runnable>(),
             threadFactory);
 
     allowCoreThreadTimeout(executor, true);

--- a/BoltsTest/src/bolts/AndroidExecutorsTest.java
+++ b/BoltsTest/src/bolts/AndroidExecutorsTest.java
@@ -23,7 +23,6 @@ public class AndroidExecutorsTest extends InstrumentationTestCase {
   private static final int CORE_POOL_SIZE = AndroidExecutors.CORE_POOL_SIZE;
   private static final int MAX_POOL_SIZE = AndroidExecutors.MAX_POOL_SIZE;
   private static final int THREAD_TIMEOUT = (int)(AndroidExecutors.KEEP_ALIVE_TIME * 1000 * 1.1);
-  private static final int MAX_QUEUE_SIZE = AndroidExecutors.MAX_QUEUE_SIZE;
 
   LinkedList<CountDownLatch> corePoolAwaitLatchStack;
   LinkedList<CountDownLatch> corePoolEndLatchStack;
@@ -55,50 +54,6 @@ public class AndroidExecutorsTest extends InstrumentationTestCase {
     assertEquals(0, executor.getQueue().size());
 
     // Empty core pool
-    popTasks(true);
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
-      assertEquals(0, executor.getPoolSize());
-    } else {
-      assertEquals(CORE_POOL_SIZE, executor.getPoolSize());
-    }
-  }
-
-  /**
-   * Test that the queue gets filled and throws if filled over the max.
-   *
-   * Note: Core thread pool timeout is only available on android-9+
-   *
-   * @throws InterruptedException
-   */
-  public void testNewCachedThreadPoolQueue() throws InterruptedException {
-    ThreadPoolExecutor executor = (ThreadPoolExecutor) AndroidExecutors.newCachedThreadPool();
-    assertEquals(0, executor.getPoolSize());
-    pushTasks(executor, CORE_POOL_SIZE, true);
-
-    try {
-      // Fill queue to max
-      pushTasks(executor, MAX_QUEUE_SIZE, false);
-      assertEquals(CORE_POOL_SIZE, executor.getPoolSize());
-      assertEquals(MAX_QUEUE_SIZE, executor.getQueue().size());
-
-      // Overflow queue
-      pushTasks(executor, MAX_POOL_SIZE, false);
-      assertEquals(MAX_POOL_SIZE, executor.getPoolSize());
-      assertEquals(MAX_QUEUE_SIZE, executor.getQueue().size());
-
-      executor.execute(newWaitRunnable(null, null, null));
-      fail("Failed to reject operation due to full queue");
-    } catch (RejectedExecutionException e) {
-      // Do we still have our queue?
-      assertEquals(MAX_POOL_SIZE, executor.getPoolSize());
-      assertEquals(MAX_QUEUE_SIZE, executor.getQueue().size());
-    } finally {
-      // empty overflow
-      popTasks(false);
-      // empty queue
-      popTasks(false);
-    }
-
     popTasks(true);
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.GINGERBREAD) {
       assertEquals(0, executor.getPoolSize());


### PR DESCRIPTION
We should be able to enqueue more than 128 asynchronous Tasks.
