### PR TITLE
Add inner throwable stacktrace output

### DIFF
--- a/Bolts/src/bolts/Task.java
+++ b/Bolts/src/bolts/Task.java
@@ -10,6 +10,7 @@
 package bolts;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -248,10 +249,9 @@ public class Task<TResult> {
               if (causes.size() == 1) {
                 allFinished.setError(causes.get(0));
               } else {
-                Throwable[] throwables = causes.toArray(new Throwable[causes.size()]);
                 Exception error = new AggregateException(
                     String.format("There were %d exceptions.", causes.size()),
-                    throwables);
+                    causes);
                 allFinished.setError(error);
               }
             } else if (isCancelled.get()) {

--- a/BoltsTest/src/bolts/TaskTest.java
+++ b/BoltsTest/src/bolts/TaskTest.java
@@ -327,9 +327,9 @@ public class TaskTest extends InstrumentationTestCase {
             assertFalse(task.isCancelled());
 
             assertTrue(task.getError() instanceof AggregateException);
-            assertEquals(2, ((AggregateException) task.getError()).getCauses().length);
-            assertEquals(error0, ((AggregateException) task.getError()).getCauses()[0]);
-            assertEquals(error1, ((AggregateException) task.getError()).getCauses()[1]);
+            assertEquals(2, ((AggregateException) task.getError()).getInnerThrowables().size());
+            assertEquals(error0, ((AggregateException) task.getError()).getInnerThrowables().get(0));
+            assertEquals(error1, ((AggregateException) task.getError()).getInnerThrowables().get(1));
             assertEquals(error0, task.getError().getCause());
 
             for (Task<Void> t : tasks) {
@@ -529,6 +529,9 @@ public class TaskTest extends InstrumentationTestCase {
     assertEquals(2, aggregate.getErrors().size());
     assertEquals(error0, aggregate.getErrors().get(0));
     assertEquals(error1, aggregate.getErrors().get(1));
+    assertEquals(2, aggregate.getCauses().length);
+    assertEquals(error0, aggregate.getCauses()[0]);
+    assertEquals(error1, aggregate.getCauses()[1]);
 
     // Test deprecated getErrors method returns sane results with non-Exceptions
     aggregate = new AggregateException("message", new Throwable[]{ error0, error1, error2 });


### PR DESCRIPTION
Showing just the first inner throwable might not be enough, so let's output all the inner throwables like .NET does.

This also switches back the internal data model to List and makes it immutable, as well as un-deprecates a constructor since we can keep original behavior with subtyped generics.

Example stacktrace:
```
bolts.AggregateException: There were 2 exceptions.
        at bolts.Task$3.then(Task.java:252)
        at bolts.Task$3.then(Task.java:234)
        at bolts.Task$9.run(Task.java:453)
        at bolts.BoltsExecutors$ImmediateExecutor.execute(BoltsExecutors.java:97)
        at bolts.Task.completeImmediately(Task.java:449)
        at bolts.Task.access$100(Task.java:28)
        at bolts.Task$5.then(Task.java:316)
        at bolts.Task$5.then(Task.java:313)
        at bolts.Task.runContinuations(Task.java:515)
        at bolts.Task.access$600(Task.java:28)
        at bolts.Task$TaskCompletionSource.trySetResult(Task.java:570)
        at bolts.Task$TaskCompletionSource.setResult(Task.java:604)
        at bolts.Task$2.run(Task.java:196)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
        at java.lang.Thread.run(Thread.java:818)
 Caused by: java.lang.RuntimeException: This task failed (0).
        at bolts.TaskTest.testWhenAllTwoErrors(TaskTest.java:300)
        at java.lang.reflect.Method.invoke(Native Method)
        at java.lang.reflect.Method.invoke(Method.java:372)
        at android.test.InstrumentationTestCase.runMethod(InstrumentationTestCase.java:214)
        at android.test.InstrumentationTestCase.runTest(InstrumentationTestCase.java:199)
        at junit.framework.TestCase.runBare(TestCase.java:134)
        at junit.framework.TestResult$1.protect(TestResult.java:115)
        at junit.framework.TestResult.runProtected(TestResult.java:133)
        at junit.framework.TestResult.run(TestResult.java:118)
        at junit.framework.TestCase.run(TestCase.java:124)
        at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:191)
        at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:176)
        at android.test.InstrumentationTestRunner.onStart(InstrumentationTestRunner.java:555)
        at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:1837)
Inner throwable #0: java.lang.RuntimeException: This task failed (0).
        at bolts.TaskTest.testWhenAllTwoErrors(TaskTest.java:300)
        at java.lang.reflect.Method.invoke(Native Method)
        at java.lang.reflect.Method.invoke(Method.java:372)
        at android.test.InstrumentationTestCase.runMethod(InstrumentationTestCase.java:214)
        at android.test.InstrumentationTestCase.runTest(InstrumentationTestCase.java:199)
        at junit.framework.TestCase.runBare(TestCase.java:134)
        at junit.framework.TestResult$1.protect(TestResult.java:115)
        at junit.framework.TestResult.runProtected(TestResult.java:133)
        at junit.framework.TestResult.run(TestResult.java:118)
        at junit.framework.TestCase.run(TestCase.java:124)
        at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:191)
        at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:176)
        at android.test.InstrumentationTestRunner.onStart(InstrumentationTestRunner.java:555)
        at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:1837)
Inner throwable #1: java.lang.RuntimeException: This task failed (1).
        at bolts.TaskTest.testWhenAllTwoErrors(TaskTest.java:301)
        at java.lang.reflect.Method.invoke(Native Method)
        at java.lang.reflect.Method.invoke(Method.java:372)
        at android.test.InstrumentationTestCase.runMethod(InstrumentationTestCase.java:214)
        at android.test.InstrumentationTestCase.runTest(InstrumentationTestCase.java:199)
        at junit.framework.TestCase.runBare(TestCase.java:134)
        at junit.framework.TestResult$1.protect(TestResult.java:115)
        at junit.framework.TestResult.runProtected(TestResult.java:133)
        at junit.framework.TestResult.run(TestResult.java:118)
        at junit.framework.TestCase.run(TestCase.java:124)
        at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:191)
        at android.test.AndroidTestRunner.runTest(AndroidTestRunner.java:176)
        at android.test.InstrumentationTestRunner.onStart(InstrumentationTestRunner.java:555)
        at android.app.Instrumentation$InstrumentationThread.run(Instrumentation.java:1837)
```