### PR TITLE
Support throwing CancellationException from a Continuation or Callable 

### DIFF
--- a/Bolts/src/bolts/Continuation.java
+++ b/Bolts/src/bolts/Continuation.java
@@ -11,6 +11,10 @@ package bolts;
 
 /**
  * A function to be called after a task completes.
+ *
+ * If you wish to have the Task from a Continuation that does not return a Task be cancelled
+ * then throw a {@link java.util.concurrent.CancellationException} from the Continuation.
+ *
  * @see Task
  */
 public interface Continuation<TTaskResult, TContinuationResult> {

--- a/Bolts/src/bolts/Task.java
+++ b/Bolts/src/bolts/Task.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -178,6 +179,9 @@ public class Task<TResult> {
 
   /**
    * Invokes the callable on a background thread, returning a Task to represent the operation.
+   *
+   * If you want to cancel the resulting Task throw a {@link java.util.concurrent.CancellationException}
+   * from the callable.
    */
   public static <TResult> Task<TResult> callInBackground(Callable<TResult> callable) {
     return call(callable, BACKGROUND_EXECUTOR);
@@ -185,6 +189,9 @@ public class Task<TResult> {
 
   /**
    * Invokes the callable using the given executor, returning a Task to represent the operation.
+   *
+   * If you want to cancel the resulting Task throw a {@link java.util.concurrent.CancellationException}
+   * from the callable.
    */
   public static <TResult> Task<TResult> call(final Callable<TResult> callable, Executor executor) {
     final Task<TResult>.TaskCompletionSource tcs = Task.create();
@@ -193,6 +200,8 @@ public class Task<TResult> {
       public void run() {
         try {
           tcs.setResult(callable.call());
+        } catch (CancellationException e) {
+          tcs.setCancelled();
         } catch (Exception e) {
           tcs.setError(e);
         }
@@ -203,6 +212,9 @@ public class Task<TResult> {
 
   /**
    * Invokes the callable on the current thread, producing a Task.
+   *
+   * If you want to cancel the resulting Task throw a {@link java.util.concurrent.CancellationException}
+   * from the callable.
    */
   public static <TResult> Task<TResult> call(final Callable<TResult> callable) {
     return call(callable, IMMEDIATE_EXECUTOR);
@@ -452,6 +464,8 @@ public class Task<TResult> {
         try {
           TContinuationResult result = continuation.then(task);
           tcs.setResult(result);
+        } catch (CancellationException e) {
+          tcs.setCancelled();
         } catch (Exception e) {
           tcs.setError(e);
         }
@@ -501,6 +515,8 @@ public class Task<TResult> {
               }
             });
           }
+        } catch (CancellationException e) {
+          tcs.setCancelled();
         } catch (Exception e) {
           tcs.setError(e);
         }


### PR DESCRIPTION
Allows a Callable or Continuation that returns a result that is not a task to be cancelled by throwing a CancellationException from the `call` or `then` method.

This paves the way for CancellationTokens to be added and used in a non-task Continuation or Callable.

A continuation which does return a Task should continue to prefer returning `Task.cancelled()` to avoid the overhead of exception handling.

Matches up with C# OperationCanceledException