### PR TITLE
Implement bolts.TaskCompletionSource, deprecate bolts.Task.TaskCompletionSource

### DIFF
--- a/Bolts/src/main/java/bolts/Task.java
+++ b/Bolts/src/main/java/bolts/Task.java
@@ -54,18 +54,15 @@ public class Task<TResult> {
   private Exception error;
   private List<Continuation<TResult, Void>> continuations;
 
-  private Task() {
-    continuations = new ArrayList<Continuation<TResult, Void>>();
+  /* package */ Task() {
+    continuations = new ArrayList<>();
   }
 
   /**
-   * Creates a TaskCompletionSource that orchestrates a Task. This allows the creator of a task to
-   * be solely responsible for its completion.
-   *
-   * @return A new TaskCompletionSource.
+   * @deprecated Please use {@link bolts.TaskCompletionSource()} instead.
    */
   public static <TResult> Task<TResult>.TaskCompletionSource create() {
-    Task<TResult> task = new Task<TResult>();
+    Task<TResult> task = new Task<>();
     return task.new TaskCompletionSource();
   }
 
@@ -129,8 +126,9 @@ public class Task<TResult> {
   /**
    * Creates a completed task with the given value.
    */
+  @SuppressWarnings("unchecked")
   public static <TResult> Task<TResult> forResult(TResult value) {
-    Task<TResult>.TaskCompletionSource tcs = Task.create();
+    bolts.TaskCompletionSource<TResult> tcs = new bolts.TaskCompletionSource<>();
     tcs.setResult(value);
     return tcs.getTask();
   }
@@ -139,7 +137,7 @@ public class Task<TResult> {
    * Creates a faulted task with the given error.
    */
   public static <TResult> Task<TResult> forError(Exception error) {
-    Task<TResult>.TaskCompletionSource tcs = Task.create();
+    bolts.TaskCompletionSource<TResult> tcs = new bolts.TaskCompletionSource<>();
     tcs.setError(error);
     return tcs.getTask();
   }
@@ -147,8 +145,9 @@ public class Task<TResult> {
   /**
    * Creates a cancelled task.
    */
+  @SuppressWarnings("unchecked")
   public static <TResult> Task<TResult> cancelled() {
-    Task<TResult>.TaskCompletionSource tcs = Task.create();
+    bolts.TaskCompletionSource<TResult> tcs = new bolts.TaskCompletionSource<>();
     tcs.setCancelled();
     return tcs.getTask();
   }
@@ -184,7 +183,7 @@ public class Task<TResult> {
       return Task.forResult(null);
     }
 
-    final Task<Void>.TaskCompletionSource tcs = Task.create();
+    final bolts.TaskCompletionSource<Void> tcs = new bolts.TaskCompletionSource<>();
     final ScheduledFuture<?> scheduled = executor.schedule(new Runnable() {
       @Override
       public void run() {
@@ -265,7 +264,7 @@ public class Task<TResult> {
    */
   public static <TResult> Task<TResult> call(final Callable<TResult> callable, Executor executor,
       final CancellationToken ct) {
-    final Task<TResult>.TaskCompletionSource tcs = Task.create();
+    final bolts.TaskCompletionSource<TResult> tcs = new bolts.TaskCompletionSource<>();
     executor.execute(new Runnable() {
       @Override
       public void run() {
@@ -320,7 +319,7 @@ public class Task<TResult> {
       return Task.forResult(null);
     }
 
-    final Task<Task<TResult>>.TaskCompletionSource firstCompleted = Task.create();
+    final bolts.TaskCompletionSource<Task<TResult>> firstCompleted = new bolts.TaskCompletionSource<>();
     final AtomicBoolean isAnyTaskComplete = new AtomicBoolean(false);
 
     for (Task<TResult> task : tasks) {
@@ -355,7 +354,7 @@ public class Task<TResult> {
       return Task.forResult(null);
     }
       
-    final Task<Task<?>>.TaskCompletionSource firstCompleted = Task.create();
+    final bolts.TaskCompletionSource<Task<?>> firstCompleted = new bolts.TaskCompletionSource<>();
     final AtomicBoolean isAnyTaskComplete = new AtomicBoolean(false);
       
     for (Task<?> task : tasks) {
@@ -439,8 +438,8 @@ public class Task<TResult> {
       return Task.forResult(null);
     }
 
-    final Task<Void>.TaskCompletionSource allFinished = Task.create();
-    final ArrayList<Exception> causes = new ArrayList<Exception>();
+    final bolts.TaskCompletionSource<Void> allFinished = new bolts.TaskCompletionSource<>();
+    final ArrayList<Exception> causes = new ArrayList<>();
     final Object errorLock = new Object();
     final AtomicInteger count = new AtomicInteger(tasks.size());
     final AtomicBoolean isCancelled = new AtomicBoolean(false);
@@ -520,7 +519,7 @@ public class Task<TResult> {
       final Continuation<Void, Task<Void>> continuation, final Executor executor,
       final CancellationToken ct) {
     final Capture<Continuation<Void, Task<Void>>> predicateContinuation =
-        new Capture<Continuation<Void, Task<Void>>>();
+        new Capture<>();
     predicateContinuation.set(new Continuation<Void, Task<Void>>() {
       @Override
       public Task<Void> then(Task<Void> task) throws Exception {
@@ -557,7 +556,7 @@ public class Task<TResult> {
       final Continuation<TResult, TContinuationResult> continuation, final Executor executor,
       final CancellationToken ct) {
     boolean completed;
-    final Task<TContinuationResult>.TaskCompletionSource tcs = Task.create();
+    final bolts.TaskCompletionSource<TContinuationResult> tcs = new bolts.TaskCompletionSource<>();
     synchronized (lock) {
       completed = this.isCompleted();
       if (!completed) {
@@ -611,7 +610,7 @@ public class Task<TResult> {
       final Continuation<TResult, Task<TContinuationResult>> continuation, final Executor executor,
       final CancellationToken ct) {
     boolean completed;
-    final Task<TContinuationResult>.TaskCompletionSource tcs = Task.create();
+    final bolts.TaskCompletionSource<TContinuationResult> tcs = new bolts.TaskCompletionSource<>();
     synchronized (lock) {
       completed = this.isCompleted();
       if (!completed) {
@@ -769,7 +768,7 @@ public class Task<TResult> {
    *          scheduled on a different thread).
    */
   private static <TContinuationResult, TResult> void completeImmediately(
-      final Task<TContinuationResult>.TaskCompletionSource tcs,
+      final bolts.TaskCompletionSource<TContinuationResult> tcs,
       final Continuation<TResult, TContinuationResult> continuation, final Task<TResult> task,
       Executor executor, final CancellationToken ct) {
     executor.execute(new Runnable() {
@@ -809,7 +808,7 @@ public class Task<TResult> {
    *          scheduled on a different thread).
    */
   private static <TContinuationResult, TResult> void completeAfterTask(
-      final Task<TContinuationResult>.TaskCompletionSource tcs,
+      final bolts.TaskCompletionSource<TContinuationResult> tcs,
       final Continuation<TResult, Task<TContinuationResult>> continuation,
       final Task<TResult> task, final Executor executor,
       final CancellationToken ct) {
@@ -870,95 +869,59 @@ public class Task<TResult> {
   }
 
   /**
-   * Allows safe orchestration of a task's completion, preventing the consumer from prematurely
-   * completing the task. Essentially, it represents the producer side of a Task<TResult>, providing
-   * access to the consumer side through the getTask() method while isolating the Task's completion
-   * mechanisms from the consumer.
+   * Sets the cancelled flag on the Task if the Task hasn't already been completed.
    */
-  public class TaskCompletionSource {
-    private TaskCompletionSource() {
-    }
-
-    /**
-     * @return the Task associated with this TaskCompletionSource.
-     */
-    public Task<TResult> getTask() {
-      return Task.this;
-    }
-
-    /**
-     * Sets the cancelled flag on the Task if the Task hasn't already been completed.
-     */
-    public boolean trySetCancelled() {
-      synchronized (lock) {
-        if (complete) {
-          return false;
-        }
-        complete = true;
-        cancelled = true;
-        lock.notifyAll();
-        runContinuations();
-        return true;
+  /* package */ boolean trySetCancelled() {
+    synchronized (lock) {
+      if (complete) {
+        return false;
       }
+      complete = true;
+      cancelled = true;
+      lock.notifyAll();
+      runContinuations();
+      return true;
     }
+  }
 
-    /**
-     * Sets the result on the Task if the Task hasn't already been completed.
-     */
-    public boolean trySetResult(TResult result) {
-      synchronized (lock) {
-        if (complete) {
-          return false;
-        }
-        complete = true;
-        Task.this.result = result;
-        lock.notifyAll();
-        runContinuations();
-        return true;
+  /**
+   * Sets the result on the Task if the Task hasn't already been completed.
+   */
+  /* package */ boolean trySetResult(TResult result) {
+    synchronized (lock) {
+      if (complete) {
+        return false;
       }
+      complete = true;
+      Task.this.result = result;
+      lock.notifyAll();
+      runContinuations();
+      return true;
     }
+  }
 
-    /**
-     * Sets the error on the Task if the Task hasn't already been completed.
-     */
-    public boolean trySetError(Exception error) {
-      synchronized (lock) {
-        if (complete) {
-          return false;
-        }
-        complete = true;
-        Task.this.error = error;
-        lock.notifyAll();
-        runContinuations();
-        return true;
+  /**
+   * Sets the error on the Task if the Task hasn't already been completed.
+   */
+  /* package */ boolean trySetError(Exception error) {
+    synchronized (lock) {
+      if (complete) {
+        return false;
       }
+      complete = true;
+      Task.this.error = error;
+      lock.notifyAll();
+      runContinuations();
+      return true;
     }
+  }
 
-    /**
-     * Sets the cancelled flag on the task, throwing if the Task has already been completed.
-     */
-    public void setCancelled() {
-      if (!trySetCancelled()) {
-        throw new IllegalStateException("Cannot cancel a completed task.");
-      }
-    }
+  /**
+   * @deprecated Please use {@link bolts.TaskCompletionSource} instead.
+   */
+  public class TaskCompletionSource extends bolts.TaskCompletionSource<TResult> {
 
-    /**
-     * Sets the result of the Task, throwing if the Task has already been completed.
-     */
-    public void setResult(TResult result) {
-      if (!trySetResult(result)) {
-        throw new IllegalStateException("Cannot set the result of a completed task.");
-      }
-    }
-
-    /**
-     * Sets the error of the Task, throwing if the Task has already been completed.
-     */
-    public void setError(Exception error) {
-      if (!trySetError(error)) {
-        throw new IllegalStateException("Cannot set the error on a completed task.");
-      }
+    /* package */ TaskCompletionSource() {
     }
   }
 }

--- a/Bolts/src/main/java/bolts/TaskCompletionSource.java
+++ b/Bolts/src/main/java/bolts/TaskCompletionSource.java
@@ -1,0 +1,75 @@
+package bolts;
+
+/**
+ * Allows safe orchestration of a task's completion, preventing the consumer from prematurely
+ * completing the task. Essentially, it represents the producer side of a Task<TResult>, providing
+ * access to the consumer side through the getTask() method while isolating the Task's completion
+ * mechanisms from the consumer.
+ */
+public class TaskCompletionSource<TResult> {
+
+  private final Task<TResult> task;
+
+  /**
+   * Creates a TaskCompletionSource that orchestrates a Task. This allows the creator of a task to
+   * be solely responsible for its completion.
+   */
+  public TaskCompletionSource() {
+    task = new Task<>();
+  }
+
+  /**
+   * @return the Task associated with this TaskCompletionSource.
+   */
+  public Task<TResult> getTask() {
+    return task;
+  }
+
+  /**
+   * Sets the cancelled flag on the Task if the Task hasn't already been completed.
+   */
+  public boolean trySetCancelled() {
+    return task.trySetCancelled();
+  }
+
+  /**
+   * Sets the result on the Task if the Task hasn't already been completed.
+   */
+  public boolean trySetResult(TResult result) {
+    return task.trySetResult(result);
+  }
+
+  /**
+   * Sets the error on the Task if the Task hasn't already been completed.
+   */
+  public boolean trySetError(Exception error) {
+    return task.trySetError(error);
+  }
+
+  /**
+   * Sets the cancelled flag on the task, throwing if the Task has already been completed.
+   */
+  public void setCancelled() {
+    if (!trySetCancelled()) {
+      throw new IllegalStateException("Cannot cancel a completed task.");
+    }
+  }
+
+  /**
+   * Sets the result of the Task, throwing if the Task has already been completed.
+   */
+  public void setResult(TResult result) {
+    if (!trySetResult(result)) {
+      throw new IllegalStateException("Cannot set the result of a completed task.");
+    }
+  }
+
+  /**
+   * Sets the error of the Task, throwing if the Task has already been completed.
+   */
+  public void setError(Exception error) {
+    if (!trySetError(error)) {
+      throw new IllegalStateException("Cannot set the error on a completed task.");
+    }
+  }
+}

--- a/Bolts/src/main/java/bolts/WebViewAppLinkResolver.java
+++ b/Bolts/src/main/java/bolts/WebViewAppLinkResolver.java
@@ -125,7 +125,7 @@ public class WebViewAppLinkResolver implements AppLinkResolver {
       @Override
       public Task<JSONArray> then(Task<Void> task) throws Exception {
         // Load the content in a WebView and use JavaScript to extract the meta tags.
-        final Task<JSONArray>.TaskCompletionSource tcs = Task.create();
+        final TaskCompletionSource<JSONArray> tcs = new TaskCompletionSource<>();
         final WebView webView = new WebView(context);
         webView.getSettings().setJavaScriptEnabled(true);
         webView.setNetworkAvailable(false);

--- a/Bolts/src/test/java/bolts/TaskTest.java
+++ b/Bolts/src/test/java/bolts/TaskTest.java
@@ -964,17 +964,18 @@ public class TaskTest {
     runTaskTest(new Callable<Task<?>>() {
       public Task<?> call() throws Exception {
         return Task.forResult(null).continueWhile(new Callable<Boolean>() {
-          public Boolean call() throws Exception {
-            return count.get() < 10;
-          }
-        }, new Continuation<Void, Task<Void>>() {
-          public Task<Void> then(Task<Void> task) throws Exception {
-            if (count.incrementAndGet() == 5) {
-              cts.cancel();
-            }
-            return null;
-          }
-        }, Executors.newCachedThreadPool(),
+                                                    public Boolean call() throws Exception {
+                                                      return count.get() < 10;
+                                                    }
+                                                  }, new Continuation<Void, Task<Void>>() {
+                                                    public Task<Void> then(Task<Void> task)
+                                                        throws Exception {
+                                                      if (count.incrementAndGet() == 5) {
+                                                        cts.cancel();
+                                                      }
+                                                      return null;
+                                                    }
+                                                  }, Executors.newCachedThreadPool(),
             cts.getToken()).continueWith(new Continuation<Void, Void>() {
           public Void then(Task<Void> task) throws Exception {
             assertTrue(task.isCancelled());
@@ -1064,6 +1065,20 @@ public class TaskTest {
 
   //endregion
 
+  //region deprecated
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void testDeprecatedTaskCompletionSource() {
+    Task<Void>.TaskCompletionSource tcsA = Task.create();
+    tcsA.setResult(null);
+    assertTrue(tcsA.getTask().isCompleted());
+
+    TaskCompletionSource<Void> tcsB = Task.create();
+    tcsB.setResult(null);
+    assertTrue(tcsA.getTask().isCompleted());
+  }
+
   @SuppressWarnings("deprecation")
   @Test
   public void testDeprecatedAggregateExceptionMethods() {
@@ -1094,4 +1109,6 @@ public class TaskTest {
     assertNotSame(error2, aggregate.getErrors().get(2));
     assertEquals(error2, aggregate.getErrors().get(2).getCause());
   }
+
+  //endregion
 }

--- a/Bolts/src/test/java/bolts/TaskTest.java
+++ b/Bolts/src/test/java/bolts/TaskTest.java
@@ -22,6 +22,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class TaskTest {
@@ -733,7 +734,7 @@ public class TaskTest {
       public Task<?> call() throws Exception {
         final ArrayList<Task<Void>> tasks = new ArrayList<>();
         for (int i = 0; i < 20; i++) {
-          final Task<Void>.TaskCompletionSource tcs = Task.create();
+          final TaskCompletionSource<Void> tcs = new TaskCompletionSource<>();
 
           final int number = i;
           Task.callInBackground(new Callable<Void>() {

--- a/Bolts/src/test/java/bolts/TaskTest.java
+++ b/Bolts/src/test/java/bolts/TaskTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 public class TaskTest {


### PR DESCRIPTION
Removes the weird syntax:

```java
// Before:
Task<Void>.TaskCompletionSource tcs = Task.create();

// After:
TaskCompletionSource<Void> tcs = Task.create();
TaskCompletionSource<Void> tcs = new TaskCompletionSource<>();
```

Deprecated APIs:
`bolts.Task<TResult>.TaskCompletionSource`
`bolts.Task.create()`

New APIs:
`bolts.TaskCompletionSource<TResult>` (new class, same methods as from `bolts.Task<TResult>.TaskCompletionSource`)
`new bolts.TaskCompletionSource<>()`

The constructor is so that we don't always have to use `Task.create()` which creates the anonymous inner class bs.