### PR TITLE
Add equivalent to .net Task.Result

### DIFF
--- a/bolts-tasks/src/main/java/bolts/TaskCanceledException.java
+++ b/bolts-tasks/src/main/java/bolts/TaskCanceledException.java
@@ -1,0 +1,26 @@
+package bolts;
+
+/**
+ * Represents an exception used to communicate task cancellation.
+ */
+public class TaskCanceledException extends RuntimeException {
+  private final Task<?> canceledTask;
+
+  /**
+   * Constructs a new {@code TaskCanceledException} with the current stack trace, and with a
+   * reference to the task that is the cause of this exception.
+   *
+   * @param canceledTask
+   *            The task that was canceled.
+   */
+  TaskCanceledException(Task<?> canceledTask) {
+    this.canceledTask = canceledTask;
+  }
+
+  /**
+   * @return The task associated with this exception.
+   */
+  public Task<?> getTask() {
+    return canceledTask;
+  }
+}


### PR DESCRIPTION
I would love to replace getResult() rather than add waitAndGetResult(),
since the current getResult() just feels broken; however that would be a
rather big breaking change.