### PR TITLE
Monitor for unobserved errors

### DIFF
--- a/bolts-tasks/src/main/java/bolts/UnobservedErrorNotifier.java
+++ b/bolts-tasks/src/main/java/bolts/UnobservedErrorNotifier.java
@@ -1,0 +1,33 @@
+package bolts;
+
+/**
+ * This class is used to retain a faulted task until either its error is observed or it is
+ * finalized. If it is finalized with a task, then the uncaught exception handler is exected
+ * with an UnobservedTaskException.
+ */
+class UnobservedErrorNotifier {
+  private Task<?> task;
+
+  public UnobservedErrorNotifier(Task<?> task) {
+      this.task = task;
+  }
+
+  @Override
+  protected void finalize() throws Throwable {
+    try {
+      Task faultedTask = this.task;
+      if (faultedTask != null) {
+        Task.UnobservedExceptionHandler ueh = Task.getUnobservedExceptionHandler();
+        if (ueh != null) {
+          ueh.unobservedException(faultedTask, new UnobservedTaskException(faultedTask.getError()));
+        }
+      }
+    } finally {
+      super.finalize();
+    }
+  }
+
+  public void setObserved() {
+    task = null;
+  }
+}

--- a/bolts-tasks/src/main/java/bolts/UnobservedTaskException.java
+++ b/bolts-tasks/src/main/java/bolts/UnobservedTaskException.java
@@ -1,0 +1,10 @@
+package bolts;
+
+/**
+ * Used to signify that a Task's error went unobserved.
+ */
+public class UnobservedTaskException extends RuntimeException {
+  public UnobservedTaskException(Throwable cause) {
+    super(cause);
+  }
+}


### PR DESCRIPTION
This defers the actual finalization handling to a secondary class.
Additionally if any of the continuations immediately observe the error,
then no additional finalization logic is performed.

Fixes #48