### PR TITLE
continuation with bad Executor leads to un-predictable result and the Exception is hidden

### DIFF
--- a/bolts-tasks/src/main/java/bolts/ExecutorException.java
+++ b/bolts-tasks/src/main/java/bolts/ExecutorException.java
@@ -1,0 +1,11 @@
+package bolts;
+
+/**
+ * This is a wrapper class for emphasizing that task failed due to bad Executor, rather than the continuation block it self.
+ */
+public class ExecutorException extends RuntimeException {
+
+    public ExecutorException(Exception e) {
+        super("An exception was thrown by a Executor", e);
+    }
+}

--- a/bolts-tasks/src/test/java/bolts/TaskTest.java
+++ b/bolts-tasks/src/test/java/bolts/TaskTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -1022,6 +1023,91 @@ public class TaskTest {
             return null;
           }
         });
+      }
+    });
+  }
+
+  @Test
+  public void testCallWithBadExecutor() {
+    final RuntimeException exception = new RuntimeException("BAD EXECUTORS");
+
+    Task.call(new Callable<Integer>() {
+      public Integer call() throws Exception {
+        return 1;
+      }
+    }, new Executor() {
+      @Override
+      public void execute(Runnable command) {
+        throw exception;
+      }
+    }).continueWith(new Continuation<Integer, Object>() {
+      @Override
+      public Object then(Task<Integer> task) throws Exception {
+        assertTrue(task.isFaulted());
+        assertTrue(task.getError() instanceof ExecutorException);
+        assertEquals(exception, task.getError().getCause());
+
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void testContinueWithBadExecutor() {
+    final RuntimeException exception = new RuntimeException("BAD EXECUTORS");
+
+    Task.call(new Callable<Integer>() {
+      public Integer call() throws Exception {
+        return 1;
+      }
+    }).continueWith(new Continuation<Integer, Integer>() {
+      @Override
+      public Integer then(Task<Integer> task) throws Exception {
+        return task.getResult();
+      }
+    }, new Executor() {
+      @Override
+      public void execute(Runnable command) {
+        throw exception;
+      }
+    }).continueWith(new Continuation<Integer, Object>() {
+      @Override
+      public Object then(Task<Integer> task) throws Exception {
+        assertTrue(task.isFaulted());
+        assertTrue(task.getError() instanceof ExecutorException);
+        assertEquals(exception, task.getError().getCause());
+
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void testContinueWithTaskAndBadExecutor() {
+    final RuntimeException exception = new RuntimeException("BAD EXECUTORS");
+
+    Task.call(new Callable<Integer>() {
+      public Integer call() throws Exception {
+        return 1;
+      }
+    }).continueWithTask(new Continuation<Integer, Task<Integer>>() {
+      @Override
+      public Task<Integer> then(Task<Integer> task) throws Exception {
+        return task;
+      }
+    }, new Executor() {
+      @Override
+      public void execute(Runnable command) {
+        throw exception;
+      }
+    }).continueWith(new Continuation<Integer, Object>() {
+      @Override
+      public Object then(Task<Integer> task) throws Exception {
+        assertTrue(task.isFaulted());
+        assertTrue(task.getError() instanceof ExecutorException);
+        assertEquals(exception, task.getError().getCause());
+
+        return null;
       }
     });
   }


### PR DESCRIPTION
I'm using bolts heavily with Executor to synchronizes the continuation blocks. 
When i made a mistake in the Executor implementation, causes a NullPointerException to be raised, i found that this would crash the app due to the exception was raised to the previous Task.

The snippets kind of like below
```
Task.callInBackground(T1).onSuccess(new Continuation() {
    public Object then(Task task) { }
}, BadExecutors).continueWith(new Continuation() {
    public Object then(Task task) { 
        if (task.isFaulted()) task.getError().printStackTrace()
    }
});
```

Since the BadExecutors throws NPE, rather then having the NPE being sent to to next continuation block, it crashes the app with IllegalStateException("Cannot set the error on a completed task.")

This is caused by the the Executor.execute is not wrapped by try-catch, causing the exception being sent  back to finishing block of the previous task in the chain where the Task result being set as completed, continuations blocks is being executed

