### PR TITLE
Fix: call method 'close' of CancellationTokenSource leads to Concurre…

### DIFF
--- a/bolts-tasks/src/main/java/bolts/CancellationTokenSource.java
+++ b/bolts-tasks/src/main/java/bolts/CancellationTokenSource.java
@@ -129,10 +129,11 @@ public class CancellationTokenSource implements Closeable {
 
       cancelScheduledCancellation();
 
+      List<CancellationTokenRegistration> registrations = new ArrayList<>(this.registrations);
       for (CancellationTokenRegistration registration : registrations) {
         registration.close();
       }
-      registrations.clear();
+      this.registrations.clear();
       closed = true;
     }
   }

--- a/bolts-tasks/src/test/java/bolts/CancellationTest.java
+++ b/bolts-tasks/src/test/java/bolts/CancellationTest.java
@@ -173,4 +173,19 @@ public class CancellationTest {
     assertNull(result1.get());
     assertNotNull(result2.get());
   }
+
+  @Test
+  public void testCloseCancellationTokenSource() {
+    CancellationTokenSource cts = new CancellationTokenSource();
+    CancellationToken token = cts.getToken();
+
+    token.register(new Runnable() {
+      @Override
+      public void run() {
+        // Do nothing
+      }
+    });
+
+    cts.close();
+  }
 }


### PR DESCRIPTION
close CancellationTokenSource directly leads to ConcurrentModificationException to the ListArray 'registrations', because each CancellationTokenRegistration would remove itself from the CancellationTokenSource when in its 'close' method 
